### PR TITLE
Fixed missing required environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,8 @@ SMTP_PASSWORD=smtpPassword
 
 NEXT_TELEMETRY_DISABLED 1
 
+TERMS_URL=www.example.com/terms
+PRIVACY_URL=www.example.com/privacy
+
 # For Docker Compose Setup use this Database URL:
 # DATABASE_URL='postgresql://postgres:postgres@postgres:5432/snoopforms?schema=public'


### PR DESCRIPTION
The next configuration refers to two required values `process.env.TERMS_URL` and `process.env.PRIVACY_URL` that are currently missing from the example .env.example file that is copied during the local deployment instructions.

I have added sensible default values to this file which allows the build to complete.