### PR TITLE
Add default flow if SMTP data not provided

### DIFF
--- a/lib/email.ts
+++ b/lib/email.ts
@@ -57,3 +57,11 @@ export const sendVerificationEmail = async (user) => {
     Your snoopForms Team`,
   });
 };
+
+export const canSendEmails = (): boolean => {
+  return serverRuntimeConfig.smtpHost
+      && serverRuntimeConfig.smtpPort
+      && serverRuntimeConfig.smtpUser
+      && serverRuntimeConfig.smtpPassword
+      && serverRuntimeConfig.mailFrom
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -57,11 +57,3 @@ export const sendVerificationEmail = async (user) => {
     Your snoopForms Team`,
   });
 };
-
-export const canSendEmails = (): boolean => {
-  return serverRuntimeConfig.smtpHost
-      && serverRuntimeConfig.smtpPort
-      && serverRuntimeConfig.smtpUser
-      && serverRuntimeConfig.smtpPassword
-      && serverRuntimeConfig.mailFrom
-}

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,7 @@ const nextConfig = {
     posthogApiKey: process.env.POSTHOG_API_KEY,
     termsUrl: process.env.TERMS_URL,
     privacyUrl: process.env.PRIVACY_URL,
+    emailVerificationDisabled: process.env.EMAIL_VERIFICATION_DISABLED
   },
   async redirects() {
     return [

--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,7 @@ const nextConfig = {
     posthogApiKey: process.env.POSTHOG_API_KEY,
     termsUrl: process.env.TERMS_URL,
     privacyUrl: process.env.PRIVACY_URL,
-    emailVerificationDisabled: process.env.EMAIL_VERIFICATION_DISABLED
+    emailVerificationDisabled: process.env.EMAIL_VERIFICATION_DISABLED === '1'
   },
   async redirects() {
     return [

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -6,7 +6,7 @@ import CredentialsProvider from "next-auth/providers/credentials";
 import { prisma } from "../../../lib/prisma";
 import { verifyPassword } from "../../../lib/auth";
 
-const { serverRuntimeConfig } = getConfig();
+const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   return await NextAuth(req, res, {
@@ -142,7 +142,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
     ],
     callbacks: {
       async signIn({ user }) {
-        if (user.emailVerified) {
+        if (user.emailVerified || publicRuntimeConfig.emailVerificationDisabled) {
           return true;
         } else {
           // Return false to display a default error message or you can return a URL to redirect to

--- a/pages/auth/signup-without-verification-success.tsx
+++ b/pages/auth/signup-without-verification-success.tsx
@@ -1,0 +1,47 @@
+import Image from "next/image";
+import { useRouter } from "next/router";
+import BaseLayoutUnauthorized from "../../components/layout/BaseLayoutUnauthorized";
+
+export default function SignupWithoutVerificationSuccess() {
+    const router = useRouter();
+
+    return (
+        <BaseLayoutUnauthorized title="Verify your email">
+            <div className="flex min-h-screen bg-ui-gray-light">
+                <div
+                    className="flex flex-col justify-center flex-1 px-4 py-12 mx-auto sm:px-6 lg:flex-none lg:px-20 xl:px-24">
+                    <div className="w-full max-w-sm p-8 mx-auto bg-white rounded-xl shadow-cont lg:w-96">
+                        <div>
+                            <Image
+                                src="/img/snoopforms-logo.svg"
+                                alt="snoopForms logo"
+                                width={500}
+                                height={89}
+                            />
+                        </div>
+
+                        <div className="mt-8">
+                            <h1 className="mb-4 font-bold text-center leading-2">
+                                User successfully created
+                            </h1>
+                            <p className="text-center">
+                                Your new user has been created successfully. Please
+                                click the button below and sign in to your account.
+                            </p>
+                            <hr className="my-4"/>
+                            <button
+                                type="button"
+                                onClick={() => router.push(
+                                    '/'
+                                )}
+                                className="flex justify-center w-full px-4 py-2 mt-5 text-sm font-medium text-gray-600 bg-white border border-gray-400 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                            >
+                                Login
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </BaseLayoutUnauthorized>
+    );
+}

--- a/pages/auth/signup.tsx
+++ b/pages/auth/signup.tsx
@@ -16,16 +16,21 @@ export default function SignUpPage() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await createUser(
+
+      // Extracts emailVerified property from user which is only set on signup if SMTP data is not provided
+      const { emailVerified } = await createUser(
         e.target.elements.firstname.value,
         e.target.elements.lastname.value,
         e.target.elements.email.value,
         e.target.elements.password.value
       );
-      router.push(
-        `/auth/verification-requested?email=${encodeURIComponent(
+
+      const url = !!emailVerified ? `/auth/signup-without-verification-success` : `/auth/verification-requested?email=${encodeURIComponent(
           e.target.elements.email.value
-        )}`
+      )}`
+
+      router.push(
+        url
       );
     } catch (e) {
       setError(e.message);

--- a/pages/auth/signup.tsx
+++ b/pages/auth/signup.tsx
@@ -13,19 +13,20 @@ export default function SignUpPage() {
   const router = useRouter();
   const [error, setError] = useState<string>("");
 
+  const { emailVerificationDisabled, privacyUrl, termsUrl } = publicRuntimeConfig
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
 
-      // Extracts emailVerified property from user which is only set on signup if SMTP data is not provided
-      const { emailVerified } = await createUser(
+      await createUser(
         e.target.elements.firstname.value,
         e.target.elements.lastname.value,
         e.target.elements.email.value,
         e.target.elements.password.value
       );
 
-      const url = !!emailVerified ? `/auth/signup-without-verification-success` : `/auth/verification-requested?email=${encodeURIComponent(
+      const url = emailVerificationDisabled ? `/auth/signup-without-verification-success` : `/auth/verification-requested?email=${encodeURIComponent(
           e.target.elements.email.value
       )}`
 
@@ -163,36 +164,34 @@ export default function SignUpPage() {
                         <a className="text-red hover:text-red-600">Log in.</a>
                       </Link>
                     </div>
-                    {(publicRuntimeConfig.termsUrl ||
-                      publicRuntimeConfig.privacyUrl) && (
-                      <div className="mt-3 text-xs text-center text-gray-400">
-                        By clicking &quot;Sign Up&quot;, you agree to our
-                        <br />
-                        {publicRuntimeConfig.termsUrl && (
-                          <a
-                            className="text-red hover:text-red-600"
-                            href={publicRuntimeConfig.termsUrl}
-                            rel="noreferrer"
-                            target="_blank"
-                          >
-                            terms of service
-                          </a>
-                        )}
-                        {publicRuntimeConfig.termsUrl &&
-                          publicRuntimeConfig.privacyUrl && <span> and </span>}
-                        {publicRuntimeConfig.privacyUrl && (
-                          <a
-                            className="text-red hover:text-red-600"
-                            href={publicRuntimeConfig.privacyUrl}
-                            rel="noreferrer"
-                            target="_blank"
-                          >
-                            privacy policy
-                          </a>
-                        )}
-                        .<br />
-                        We&apos;ll occasionally send you account related emails.
-                      </div>
+                    {(termsUrl || privacyUrl) && (
+                        <div className="mt-3 text-xs text-center text-gray-400">
+                          By clicking &quot;Sign Up&quot;, you agree to our
+                          <br/>
+                          {termsUrl && (
+                              <a
+                                  className="text-red hover:text-red-600"
+                                  href={termsUrl}
+                                  rel="noreferrer"
+                                  target="_blank"
+                              >
+                                terms of service
+                              </a>
+                          )}
+                          {termsUrl && privacyUrl && <span> and </span>}
+                          {privacyUrl && (
+                              <a
+                                  className="text-red hover:text-red-600"
+                                  href={privacyUrl}
+                                  rel="noreferrer"
+                                  target="_blank"
+                              >
+                                privacy policy
+                              </a>
+                          )}
+                          .<br/>
+                          We&apos;ll occasionally send you account related emails.
+                        </div>
                     )}
                   </div>
                 </form>


### PR DESCRIPTION
- adds `canSendEmails` function which reads the SMTP config provided
- only send confirmation mail on signup when `canSendEmails` returns true
- conditionally route to verification requested page or to newly added "go to login" page.

Probably could also leave out the login step, but I felt like this is the better UX :)